### PR TITLE
[layout / word] Modal 컴포넌트 분리

### DIFF
--- a/pwa/src/components/Modal.js
+++ b/pwa/src/components/Modal.js
@@ -1,0 +1,44 @@
+import React from "react";
+import * as S from "../pages/Word/Word.style";
+import { useNavigate } from "react-router-dom";
+
+const Modal = ({ recordModal }) => {
+  const navigate = useNavigate();
+
+  const hideModal = () => {
+    recordModal.current.style = "display: none";
+  };
+
+  const goToVoiceRecord = () => {
+    navigate("/voiceRecord");
+  };
+
+  return (
+    <>
+      <S.RecordModal ref={recordModal}>
+        <S.ModalBackground />
+        <S.ModalContents>
+          <S.ModalTitle>
+            어떤 방식으로 <br /> 추억을 남길까요?
+          </S.ModalTitle>
+          <S.ModalOption onClick={goToVoiceRecord}>
+            <S.ModalOptionTitle>목소리로 남기기</S.ModalOptionTitle>
+            <S.ModalOptionIcon>{">"}</S.ModalOptionIcon>
+          </S.ModalOption>
+          <S.ModalOption>
+            <S.ModalOptionTitle>키보드로 남기기</S.ModalOptionTitle>
+            <S.ModalOptionIcon>{">"}</S.ModalOptionIcon>
+          </S.ModalOption>
+
+          <S.ModalButtonBox>
+            <S.ModalCancelButton onClick={hideModal}>
+              취소하기
+            </S.ModalCancelButton>
+          </S.ModalButtonBox>
+        </S.ModalContents>
+      </S.RecordModal>
+    </>
+  );
+};
+
+export default Modal;

--- a/pwa/src/pages/Word/Word.js
+++ b/pwa/src/pages/Word/Word.js
@@ -1,12 +1,12 @@
-import React from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useRef } from "react";
 import * as S from "./Word.style";
+import Modal from "../../components/Modal";
 
 const Word = () => {
-  const navigate = useNavigate();
+  const recordModal = useRef();
 
-  const goToVoiceRecord = () => {
-    navigate("/voiceRecord");
+  const showModal = () => {
+    recordModal.current.style = "display: block";
   };
 
   return (
@@ -25,29 +25,9 @@ const Word = () => {
           <S.TodayWordContent>기쁨</S.TodayWordContent>
         </S.TodayWord>
       </S.TodayWordContainer>
-      <S.MemoryButton>추억 남기기</S.MemoryButton>
+      <S.MemoryButton onClick={showModal}>추억 남기기</S.MemoryButton>
 
-      {/* MARK: modal */}
-      <S.RecordModal>
-        <S.ModalBackground />
-        <S.ModalContents>
-          <S.ModalTitle>
-            어떤 방식으로 <br /> 추억을 남길까요?
-          </S.ModalTitle>
-          <S.ModalOption onClick={goToVoiceRecord}>
-            <S.ModalOptionTitle>목소리로 남기기</S.ModalOptionTitle>
-            <S.ModalOptionIcon>{">"}</S.ModalOptionIcon>
-          </S.ModalOption>
-          <S.ModalOption>
-            <S.ModalOptionTitle>키보드로 남기기</S.ModalOptionTitle>
-            <S.ModalOptionIcon>{">"}</S.ModalOptionIcon>
-          </S.ModalOption>
-          {/* MARK: cancel modal */}
-          <S.ModalButtonBox>
-            <S.ModalCancelButton>취소하기</S.ModalCancelButton>
-          </S.ModalButtonBox>
-        </S.ModalContents>
-      </S.RecordModal>
+      <Modal recordModal={recordModal} />
     </S.WordContainer>
   );
 };

--- a/pwa/src/pages/Word/Word.style.js
+++ b/pwa/src/pages/Word/Word.style.js
@@ -5,6 +5,7 @@ import variables from "../../styles/variables";
 
 export const WordContainer = styled.div`
   position: relative;
+  height: 80%;
 `;
 
 export const MyInfoContainer = styled.div`
@@ -49,10 +50,11 @@ export const TodayWordContent = styled.h2`
 `;
 
 export const MemoryButton = styled.button`
+  ${variables.position("absolute", "null", "null", "0", "null")}
   ${variables.widthHeight("100%", "72px")}
+  ${variables.fontStyle("22px", 600)}
   background: ${({ theme }) => theme.style.black};
   color: ${({ theme }) => theme.style.white};
-  ${variables.fontStyle("22px", 600)}
   border-radius: 24px;
   cursor: pointer;
 `;
@@ -62,7 +64,7 @@ export const MemoryButton = styled.button`
 export const RecordModal = styled.div`
   ${variables.position("fixed", "0", "0", "null", "null")}
   ${variables.flex("row", "center", "center")}
-  ${variables.widthHeight("100vw", "100vh")}
+  ${variables.widthHeight("100%", "100%")}
 `;
 
 export const ModalBackground = styled.div`
@@ -73,11 +75,10 @@ export const ModalBackground = styled.div`
 `;
 
 export const ModalContents = styled.div`
-  ${variables.widthHeight("90%", "259px")}
-  background: ${({ theme }) => theme.style.white};
-  position: fixed;
-  bottom: 85px;
+  ${variables.position("absolute", "null", "null", "85px", "null")}
+  ${variables.widthHeight("100%", "259px")}
   padding: 15px 40px;
+  background: ${({ theme }) => theme.style.white};
   border-radius: 24px;
 
   @media (min-width: 769px) {


### PR DESCRIPTION
## :: 최근 작업 주제 (최소 1개)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 스타일링
- [x] 리팩토링
- [ ] API 통신
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 테스트 진행

<br />

## :: 구현 목표

- Modal 컴포넌트 분리

<br />

## :: 구현 사항 설명

- Word 페이지 내에서 녹음/텍스트 입력 중 선택하는 모달을 별도 컴포넌트로 분리하였습니다.
- src 하위에 components 폴더를 만들고 Modal 폴더 내에 파일을 생성하이 마이그레이션했습니다.

<br />

## :: 셀프 리뷰 (고민했던 점, 새로 알게된 부분, 어려웠던 점 등)

- 작업 중 컴포넌트 분리의 필요성을 느끼고 해당 작업을 진행했는데, 처음부터 그 필요성을 미리 파악하고 분리해 놓았다면 보다 시간을 아낄 수 있었을 것 같습니다.

<br />

## :: 기타 질문 및 특이 사항

- Modal을 Word에서 띄웠을 때 width:100%로 처리되면서 양쪽에 여백이 생기지 않는 문제가 있습니다. 추후에 해결할 예정이며, 우선은 components 폴더 공유를 위해 머지 요청드립니다.
