### PR TITLE
[function / result] 피드 공유하기 기능 구현, 라우터 수정, Signup 버튼 추가

### DIFF
--- a/pwa/src/Router.js
+++ b/pwa/src/Router.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import Splash from "./pages/Splash/Splash";
 import Login from "./pages/Account/Login";
 import Signup from "./pages/Account/Signup";
 import Feed from "./pages/Feed/Feed";
@@ -18,9 +17,9 @@ const Router = () => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Splash />} />
         <Route path="/login" element={<Login />} />
-        <Route path="/signup" element={<Signup />} />
+        {/* MARK: 시연을 위해 /signup을 main url로 설정 */}
+        <Route path="/" element={<Signup />} />
         <Route path="/feed" element={<Feed />} />
         <Route path="/feedDetail" element={<FeedDetail />} />
         <Route path="/word" element={<Word />} />

--- a/pwa/src/pages/Account/Signup.js
+++ b/pwa/src/pages/Account/Signup.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
+import axios from "axios";
 import styled from "styled-components";
 import variables from "../../styles/variables";
 
@@ -70,21 +71,21 @@ const Signup = () => {
   const createProfile = () => {
     console.log(userInfo, basicProfileImg);
     const formData = new FormData();
-    formData.append("file", basicProfileImg); // FormData에 파일 추가
+    formData.append("file", basicProfileImg);
     formData.append("email", email);
-    formData.append("password", password);
-    formData.append("checkPassword", checkPassword);
     formData.append("nickname", nickname);
 
-    fetch("http://13.124.76.165:8080/profiles", {
-      method: "POST",
-      body: formData, // FormData를 요청의 body로 전달
-    })
-      .then((response) => response.json())
-      .then((data) => {
-        if (data.nickname === nickname) {
-          navigate("/login");
-        }
+    axios
+      .post("http://13.124.76.165:8080/profiles", formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      })
+      .then((response) => {
+        console.log("프로필 생성 성공 ✨", response.data);
+      })
+      .catch((error) => {
+        console.error("프로필 생성 실패:", error);
       });
   };
 
@@ -128,6 +129,12 @@ const Signup = () => {
               />
             </FormContainer>
           </SignupForm>
+          <GoToLogin>
+            <GoToLoginText>이미 계정이 있으신가요?</GoToLoginText>
+            <GoToLoginButton onClick={() => navigate("/login")}>
+              로그인
+            </GoToLoginButton>
+          </GoToLogin>
           <SignupButton onClick={handleSignup} value={0}>
             다음으로
           </SignupButton>
@@ -226,6 +233,31 @@ const UploadMyProfileImg = styled.div`
 
 const SignupForm = styled.div`
   width: 100%;
+`;
+
+const GoToLogin = styled.div`
+  ${variables.position("absolute", "null", "50%", "120px", "null")}
+  transform: translate(50%, 0);
+  white-space: nowrap;
+`;
+
+const GoToLoginText = styled.span`
+  ${variables.fontStyle("19px", 500)}
+  line-height: 29px;
+  text-align: center;
+  letter-spacing: -0.03em;
+  color: ${({ theme }) => theme.style.gray3};
+`;
+
+const GoToLoginButton = styled.button`
+  ${variables.fontStyle("19px", 500)}
+  line-height: 29px;
+  text-align: center;
+  letter-spacing: -0.03em;
+  color: ${({ theme }) => theme.style.gray5};
+  background: none;
+  border: none;
+  cursor: pointer;
 `;
 
 const FormContainer = styled.div`

--- a/pwa/src/pages/Account/Signup.js
+++ b/pwa/src/pages/Account/Signup.js
@@ -188,6 +188,11 @@ export default Signup;
 const SignupContainer = styled.div`
   ${variables.flex("column", "center", "center")}
   padding-top: 25%;
+  margin-bottom: 82px;
+
+  @media (min-width: 769px) {
+    margin-bottom: 0px;
+  }
 `;
 
 const WelcomeContainer = styled.div`
@@ -235,31 +240,6 @@ const SignupForm = styled.div`
   width: 100%;
 `;
 
-const GoToLogin = styled.div`
-  ${variables.position("absolute", "null", "50%", "120px", "null")}
-  transform: translate(50%, 0);
-  white-space: nowrap;
-`;
-
-const GoToLoginText = styled.span`
-  ${variables.fontStyle("19px", 500)}
-  line-height: 29px;
-  text-align: center;
-  letter-spacing: -0.03em;
-  color: ${({ theme }) => theme.style.gray3};
-`;
-
-const GoToLoginButton = styled.button`
-  ${variables.fontStyle("19px", 500)}
-  line-height: 29px;
-  text-align: center;
-  letter-spacing: -0.03em;
-  color: ${({ theme }) => theme.style.gray5};
-  background: none;
-  border: none;
-  cursor: pointer;
-`;
-
 const FormContainer = styled.div`
   margin-bottom: 20px;
 `;
@@ -296,6 +276,30 @@ const FormInput = styled.input`
   }
 `;
 
+const GoToLogin = styled.div`
+  margin-top: 5%;
+  white-space: nowrap;
+`;
+
+const GoToLoginText = styled.span`
+  ${variables.fontStyle("19px", 500)}
+  line-height: 29px;
+  text-align: center;
+  letter-spacing: -0.03em;
+  color: ${({ theme }) => theme.style.gray3};
+`;
+
+const GoToLoginButton = styled.button`
+  ${variables.fontStyle("19px", 500)}
+  line-height: 29px;
+  text-align: center;
+  letter-spacing: -0.03em;
+  color: ${({ theme }) => theme.style.gray5};
+  background: none;
+  border: none;
+  cursor: pointer;
+`;
+
 const SignupButton = styled.button`
   ${variables.position("fixed", "null", "null", "0", "0")}
   ${variables.widthHeight("100%", "82px")}
@@ -304,4 +308,11 @@ const SignupButton = styled.button`
   color: ${({ theme }) => theme.style.black};
   border: none;
   cursor: pointer;
+
+  @media (min-width: 769px) {
+    position: sticky;
+    width: 375px;
+    bottom: 0px;
+    transform: translate(0px, 20px);
+  }
 `;

--- a/pwa/src/pages/Word/PictureResult/PictureResult.js
+++ b/pwa/src/pages/Word/PictureResult/PictureResult.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import axios from "axios";
 import useStore from "../../../state/store";
 import styled from "styled-components";
 import variables from "../../../styles/variables";
@@ -7,6 +8,36 @@ import variables from "../../../styles/variables";
 const PictureResult = () => {
   const { keyword, textDiary, pictureDiary } = useStore((state) => state);
   const navigate = useNavigate();
+
+  const accessToken = localStorage.getItem("accessToken");
+  const shareApiUrl = "http://13.124.76.165:8080/diaries/share";
+
+  const shareToFeed = () => {
+    let data = {
+      keyword: keyword,
+      textDiary: textDiary,
+      pictureDiary: pictureDiary,
+    };
+
+    if (accessToken) {
+      axios
+        .post(shareApiUrl, JSON.stringify(data), {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+        .then((res) => {
+          console.log(res.data);
+          navigate("/feed");
+        })
+        .catch((error) => {
+          console.error("파일 공유 실패:", error);
+        });
+    } else {
+      console.log("액세스 토큰이 존재하지 않습니다");
+    }
+  };
 
   return (
     <PictureResultContainer>
@@ -21,9 +52,7 @@ const PictureResult = () => {
         <PictureResultContentText>{textDiary}</PictureResultContentText>
       </PictureResultContent>
       <GradationBox></GradationBox>
-      <ShareButton onClick={() => navigate("/feed")}>
-        친구들과 공유하기
-      </ShareButton>
+      <ShareButton onClick={shareToFeed}>친구들과 공유하기</ShareButton>
     </PictureResultContainer>
   );
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (최소 1개)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 스타일링
- [x] 리팩토링
- [x] API 통신
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 테스트 진행

<br />

## :: 구현 목표

- 피드 공유하기 기능 구현
- 라우터 수정
- Signup 버튼 추가

<br />

## :: 구현 사항 설명

- 피드 공유하기 기능 구현: body에 이전에 응답받은 값을 넣어 서버로 전송하면 특정 데이터를 응답으로 받습니다. 이 데이터는 서버에 저장되어 자동으로 feed에 업로드됩니다. 공유된 나의 게시물은 내 피드와 친구 피드에서 함께 확인 가능합니다.
- 라우터 수정: 스플래시가 별도 url로 구성될 필요가 없다고 판단하여, 메인 Url("/")을 Signup으로 변경했습니다. 스플래시가 들어갈 경우 Signup에서 setTimeOut으로 처리할 예정입니다.
- Signup 버튼 추가: 첫 화면이 회원가입 페이지인데, 이미 회원가입을 한 유저가 로그인으로 이동할 수 있는 버튼이 없어 추가해두었습니다.

<br />

## :: 셀프 리뷰 (고민했던 점, 새로 알게된 부분, 어려웠던 점 등)

- 실 사용자의 관점에서 테스트하며 필요한 기능을 깨달을 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항

- Signup 페이지의 프로필 생성 과정에서 업로드한 이미지가 서버로 잘 전송되지 않는 문제가 있어 해결중입니다.
